### PR TITLE
gitk: fix finding line source from unstaged 'commit' when not in repo…

### DIFF
--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -3829,6 +3829,7 @@ proc show_line_source {} {
     global nullid nullid2 gitdir cdup
 
     set from_index {}
+    set id {}
     if {$cmitmode eq "tree"} {
 	set id $currentid
 	set line [expr {$diff_menu_line - $diff_menu_filebase}]
@@ -3856,7 +3857,7 @@ proc show_line_source {} {
 	    } elseif {$parents($curview,$currentid) eq $nullid2} {
 		# need to do the blame from the index
 		if {[catch {
-		    set from_index [index_sha1 $flist_menu_file]
+		    set from_index [index_sha1 [file join $cdup $flist_menu_file]]
 		} err]} {
 		    error_popup [mc "Error reading index: %s" $err]
 		    return
@@ -3876,8 +3877,11 @@ proc show_line_source {} {
     lappend blameargs | git blame -p -L$line,+1
     if {$from_index ne {}} {
 	lappend blameargs --contents -
-    } else {
+    } elseif {$id ne {}} {
 	lappend blameargs $id
+    } else {
+        error_popup [mc "No associated commit for selected file `%s' and it is not in the index. This may be a bug/unsupported." $flist_menu_file]
+        return
     }
     lappend blameargs -- [file join $cdup $flist_menu_file]
     if {[catch {


### PR DESCRIPTION
… root

If you started gitk from somewhere other than the root of the repository,
 and tried use `show origin of this line' from the context menu,
 you would get the error `can't read "id": no such variable'
 with associated stack trace.
The issue was that `git ls-files' is used to determine
 the staged status of the file, and it expects a path relative
 to the current directory, not the repository root.
Accordingly, the file path is now prefixed with the repo's cdup before
 calling the index searching procedure.

Also, detect the case where a file is neither in the index
 nor does it have an associated rev id,
 and display an error (defensive programming)

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
