### PR TITLE
t1308-config-set: fix a test that has a typo

### DIFF
--- a/t/t1308-config-set.sh
+++ b/t/t1308-config-set.sh
@@ -166,14 +166,14 @@ test_expect_success 'find value with highest priority from a configset' '
 '
 
 test_expect_success 'find value_list for a key from a configset' '
-	cat >except <<-\EOF &&
+	cat >expect <<-\EOF &&
+	lama
+	ball
 	sam
 	bat
 	hask
-	lama
-	ball
 	EOF
-	test-config configset_get_value case.baz config2 .git/config >actual &&
+	test-config configset_get_value_multi case.baz config2 .git/config >actual &&
 	test_cmp expect actual
 '
 


### PR DESCRIPTION
Change test 'find value_list for a key from a configset' to compare
result with 'expect' instead of 'except' which was a typo. Change the
test call from 'configset_get_value' to 'configset_get_value_multi'
since the test expects a list of values instead of a single value.

Signed-off-by: Tanay Abhra <tanayabh@gmail.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
